### PR TITLE
FTD Import changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,12 +3,16 @@
 ##
 ## Get latest from https://github.com/github/gitignore/blob/master/VisualStudio.gitignore
 
+
+
 # User-specific files
 *.rsuser
 *.suo
 *.user
 *.userosscache
 *.sln.docstates
+#user specific location for FTD directory
+FTD.props
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/AdvShieldProjector.cs
+++ b/AdvShieldProjector.cs
@@ -517,10 +517,9 @@ namespace AdvShields
             //tip.Add(new ProTipSegment_Text(400, $"SHIELD CLASS: {SettingsData.ShieldClass}"), BrilliantSkies.Ui.Tips.Position.Middle);
             tip.Add(new ProTipSegment_Text(400, $"Surface area {(int)ShieldHandler.Shape.SurfaceArea()} m2"), BrilliantSkies.Ui.Tips.Position.Middle);
             tip.Add(new ProTipSegment_Text(400, $"This shield dome has {(int)currentHealth}/{(int)ShieldStats.MaxHealth} health"), BrilliantSkies.Ui.Tips.Position.Middle);
-            tip.Add(new ProTipSegment_Text(400, $"This shield dome has {ShieldStats.ArmourClass} armor class (minimum 2)."), BrilliantSkies.Ui.Tips.Position.Middle);
+            tip.Add(new ProTipSegment_Text(400, $"This shield dome has {ShieldStats.ArmourClass} armor class (minimum 10)."), BrilliantSkies.Ui.Tips.Position.Middle);
             tip.Add(new ProTipSegment_Text(400, $"This shield dome has a passive regen of {ShieldStats.PassiveRegen} each second. " /* (Minimum 50, maximum 500000).*/ + $"Active regeneration takes {ShieldStats.ActualWaitTime} to begin."), BrilliantSkies.Ui.Tips.Position.Middle);
             tip.Add(new ProTipSegment_Text(400, $"This shield dome has {ShieldStats.Hardeners} Hardeners and {ShieldStats.Transformers} Transformers attatched. See the stats page for more info."), BrilliantSkies.Ui.Tips.Position.Middle);
-            if (ShieldHandler.TimeAtFullHealth > 45) tip.Add(new ProTipSegment_Text(400, "<color=green>Shield has not taken any damage for a considerable time. Power use is divided by 10 until damage is taken again (this is a buff).</color>"), BrilliantSkies.Ui.Tips.Position.Middle);
             if (Node.ConnectedCard.ToLower() != "none") tip.Add(new ProTipSegment_Text(400, $"This shield has a matrix computer with a {Node.ConnectedCard} card attached."), BrilliantSkies.Ui.Tips.Position.Middle);
             if (ShieldHandler.TargettedByContLaser) tip.Add(new ProTipSegment_Text(400, "<color=yellow>Shield is currently being attacked by a continuous laser. Regen capabilities are negatively affected.</color>"), BrilliantSkies.Ui.Tips.Position.Middle);
             if (ShieldHandler.SufferingFromDisruptor) tip.Add(new ProTipSegment_Text(400, $"<color=red>Shield is currently suffering from disruption! This is severely impacting regeneration and armor class! They are multiplied by {1f-ShieldStats.DisruptionFactor}.</color>"), BrilliantSkies.Ui.Tips.Position.Middle);
@@ -726,17 +725,17 @@ namespace AdvShields
                 */
 
                 //this is no regen just combat or idle modes
-                request.IdealPower = (power + ShieldSizePower / ShieldCircleness) * AdvShieldSettingsData.IdleEPPMulti;
+                request.IdealPower = (power + ShieldSizePower / ShieldCircleness) * DomeShieldConstants.IdleEPPMulti;
             }
             else if (ShieldHandler.isActiveRegen)
             {
                 //This is active regen
-                request.IdealPower = (power + ShieldSizePower / ShieldCircleness) * AdvShieldSettingsData.ActiveRegenEPPMulti;
+                request.IdealPower = (power + ShieldSizePower / ShieldCircleness) * DomeShieldConstants.ActiveRegenEPPMulti;
             }
             else
             {
                 //This is passive regen mode effectively
-                request.IdealPower = (power + ShieldSizePower / ShieldCircleness) * AdvShieldSettingsData.PassiveRegenEPPMulti;
+                request.IdealPower = (power + ShieldSizePower / ShieldCircleness) * DomeShieldConstants.PassiveRegenEPPMulti;
                 /*
                 request.IdealPower = ((float)(((TransformData.Length * TransformData.Width * TransformData.Height * 0.006f) + 200f) + (ShieldStats.PassiveRegen * 1.5f) * (float)Math.Round(SettingsData.ExcessDrive / 2.25f + 0.5555f, 1) / ShieldCircleness)) * ShieldStats.ActiveRectifierSavingsPercent;
                 PowerDrawDifference = ((float)(((TransformData.Length * TransformData.Width * TransformData.Height * 0.006f) + 200f) + (ShieldStats.PassiveRegen * 1.5f) * (float)Math.Round(SettingsData.ExcessDrive / 2.25f + 0.5555f, 1) * ShieldCircleness - (float)(((TransformData.Length * TransformData.Width * TransformData.Height * 0.006f) + 200f) * (float)Math.Round(SettingsData.ExcessDrive / 2.25f + 0.5555f, 1) * ShieldCircleness))) * ShieldStats.ActiveRectifierSavingsPercent;

--- a/AdvShieldProjector.cs
+++ b/AdvShieldProjector.cs
@@ -724,16 +724,19 @@ namespace AdvShields
                 request.IdealPower = ((float)((TransformData.Length * TransformData.Width * TransformData.Height * 0.006f) + 200f) * (float)Math.Round(SettingsData.ExcessDrive / 2.25f + 0.5555f, 1) / ShieldCircleness) * (1f - ((1f - ShieldStats.ActiveRectifierSavingsPercent * 0.5f)));
                 PowerDrawDifference = (float)(((TransformData.Length * TransformData.Width * TransformData.Height * 0.006f) + 200f * ShieldCircleness) + (ShieldStats.PassiveRegen * 1.5f)) - (float)((TransformData.Length * TransformData.Width * TransformData.Height * 0.00499999988824129) + 200f * (float)Math.Round(SettingsData.ExcessDrive / 2.25f + 0.5555f, 1) * ShieldCircleness) * (1f - ((1f - ShieldStats.ActiveRectifierSavingsPercent * 0.5f)));
                 */
-                request.IdealPower = power + ShieldSizePower / ShieldCircleness;
-                if (ShieldHandler.TimeAtFullHealth > 45) request.IdealPower /= 10;
+
+                //this is no regen just combat or idle modes
+                request.IdealPower = (power + ShieldSizePower / ShieldCircleness) * AdvShieldSettingsData.IdleEPPMulti;
             }
             else if (ShieldHandler.isActiveRegen)
             {
-                request.IdealPower = (power + ShieldSizePower / ShieldCircleness) * 2f;
+                //This is active regen
+                request.IdealPower = (power + ShieldSizePower / ShieldCircleness) * AdvShieldSettingsData.ActiveRegenEPPMulti;
             }
             else
             {
-                request.IdealPower = (power + ShieldSizePower / ShieldCircleness) * 1.2f;
+                //This is passive regen mode effectively
+                request.IdealPower = (power + ShieldSizePower / ShieldCircleness) * AdvShieldSettingsData.PassiveRegenEPPMulti;
                 /*
                 request.IdealPower = ((float)(((TransformData.Length * TransformData.Width * TransformData.Height * 0.006f) + 200f) + (ShieldStats.PassiveRegen * 1.5f) * (float)Math.Round(SettingsData.ExcessDrive / 2.25f + 0.5555f, 1) / ShieldCircleness)) * ShieldStats.ActiveRectifierSavingsPercent;
                 PowerDrawDifference = ((float)(((TransformData.Length * TransformData.Width * TransformData.Height * 0.006f) + 200f) + (ShieldStats.PassiveRegen * 1.5f) * (float)Math.Round(SettingsData.ExcessDrive / 2.25f + 0.5555f, 1) * ShieldCircleness - (float)(((TransformData.Length * TransformData.Width * TransformData.Height * 0.006f) + 200f) * (float)Math.Round(SettingsData.ExcessDrive / 2.25f + 0.5555f, 1) * ShieldCircleness))) * ShieldStats.ActiveRectifierSavingsPercent;

--- a/AdvShieldSettingsData.cs
+++ b/AdvShieldSettingsData.cs
@@ -11,9 +11,6 @@ namespace AdvShields
 {
     public class AdvShieldSettingsData : DataPackage
     {
-        public static float ActiveRegenEPPMulti = 2f;
-        public static float PassiveRegenEPPMulti = 1.0f;
-        public static float IdleEPPMulti = .1f;
 
         public AdvShieldSettingsData(uint uniqueId) : base(uniqueId)
         {

--- a/AdvShieldSettingsData.cs
+++ b/AdvShieldSettingsData.cs
@@ -11,6 +11,10 @@ namespace AdvShields
 {
     public class AdvShieldSettingsData : DataPackage
     {
+        public static float ActiveRegenEPPMulti = 2f;
+        public static float PassiveRegenEPPMulti = 1.0f;
+        public static float IdleEPPMulti = .1f;
+
         public AdvShieldSettingsData(uint uniqueId) : base(uniqueId)
         {
         }

--- a/AdvShieldStatusTwo.cs
+++ b/AdvShieldStatusTwo.cs
@@ -137,13 +137,13 @@ namespace DomeShieldTwo
 
                 if (ShieldHandler.CurrentDamageSustained <= 0)
                 {
-                    EPPModeMulti = AdvShieldSettingsData.IdleEPPMulti;
+                    EPPModeMulti = 1.0f; //Base cost of keeping the shield *stable*
                 } else if (ShieldHandler.isActiveRegen)
                 {
-                    EPPModeMulti = AdvShieldSettingsData.ActiveRegenEPPMulti;
+                    EPPModeMulti = DomeShieldConstants.ActiveRegenEPPMulti / DomeShieldConstants.IdleEPPMulti;
                 } else
                 {
-                    EPPModeMulti = AdvShieldSettingsData.PassiveRegenEPPMulti;
+                    EPPModeMulti = DomeShieldConstants.PassiveRegenEPPMulti / DomeShieldConstants.IdleEPPMulti;
                 }
 
                 float mainEPP = Math.Min(1.0f, EPP * EPPModeMulti);

--- a/AdvShieldStatusTwo.cs
+++ b/AdvShieldStatusTwo.cs
@@ -130,12 +130,27 @@ namespace DomeShieldTwo
         private void AffectNumbersByAvailableEnginePower()
         {
             float EPP = controller.PowerUse.FractionOfPowerRequestedThatWasProvided;
+            float EPPModeMulti = 0.0f;
             if (EPP < 1)
             { 
                 NotEnoughEnergy = true;
-                MaxHealth *= EPP;
-                ArmourClass *= EPP;
-                PassiveRegen *= (EPP / 1.5f);
+
+                if (ShieldHandler.CurrentDamageSustained <= 0)
+                {
+                    EPPModeMulti = AdvShieldSettingsData.IdleEPPMulti;
+                } else if (ShieldHandler.isActiveRegen)
+                {
+                    EPPModeMulti = AdvShieldSettingsData.ActiveRegenEPPMulti;
+                } else
+                {
+                    EPPModeMulti = AdvShieldSettingsData.PassiveRegenEPPMulti;
+                }
+
+                float mainEPP = Math.Min(1.0f, EPP * EPPModeMulti);
+                MaxHealth *= mainEPP;
+                ArmourClass *= mainEPP;
+
+                PassiveRegen *= EPP;
             }
             else NotEnoughEnergy = false;
 

--- a/DomeShieldTwo.csproj
+++ b/DomeShieldTwo.csproj
@@ -6,6 +6,11 @@
     <RunPostBuildEvent>Always</RunPostBuildEvent>
   </PropertyGroup>
 
+ <!--
+ Allows for easier setting up of file path for other installations of this project
+ -->
+  <Import Project="FTD.props" Condition="Exists('FTD.props')" />
+	
   <ItemGroup>
     <Compile Remove="shieldblocksystem\**" />
     <EmbeddedResource Remove="shieldblocksystem\**" />
@@ -18,409 +23,409 @@
 
   <ItemGroup>
     <Reference Include="Accessibility">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\Accessibility.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\Accessibility.dll</HintPath>
     </Reference>
     <Reference Include="Ai">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\Ai.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\Ai.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp-firstpass">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
     </Reference>
     <Reference Include="Breadboards">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\Breadboards.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\Breadboards.dll</HintPath>
     </Reference>
     <Reference Include="BytesHelper">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\BytesHelper.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\BytesHelper.dll</HintPath>
     </Reference>
     <Reference Include="CamControl">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\CamControl.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\CamControl.dll</HintPath>
     </Reference>
     <Reference Include="Common">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\Common.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\Common.dll</HintPath>
     </Reference>
     <Reference Include="Core">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\Core.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\Core.dll</HintPath>
     </Reference>
     <Reference Include="DataManagement">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\DataManagement.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\DataManagement.dll</HintPath>
     </Reference>
     <Reference Include="Diplomacy">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\Diplomacy.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\Diplomacy.dll</HintPath>
     </Reference>
     <Reference Include="Effects">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\Effects.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\Effects.dll</HintPath>
     </Reference>
     <Reference Include="Environments">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\Environments.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\Environments.dll</HintPath>
     </Reference>
     <Reference Include="ES2">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\ES2.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\ES2.dll</HintPath>
     </Reference>
     <Reference Include="Ftd">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\Ftd.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\Ftd.dll</HintPath>
     </Reference>
     <Reference Include="FtdIntegrationTests">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\FtdIntegrationTests.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\FtdIntegrationTests.dll</HintPath>
     </Reference>
     <Reference Include="FtdRequirements">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\FtdRequirements.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\FtdRequirements.dll</HintPath>
     </Reference>
     <Reference Include="GridCasts">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\GridCasts.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\GridCasts.dll</HintPath>
     </Reference>
     <Reference Include="InControl">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\InControl.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\InControl.dll</HintPath>
     </Reference>
     <Reference Include="Localisation">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\Localisation.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\Localisation.dll</HintPath>
     </Reference>
     <Reference Include="Modding">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\Modding.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\Modding.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Data.Sqlite">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\Mono.Data.Sqlite.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\Mono.Data.Sqlite.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Posix">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\Mono.Posix.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\Mono.Posix.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Security">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\Mono.Security.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\Mono.Security.dll</HintPath>
     </Reference>
     <Reference Include="Mono.WebBrowser">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\Mono.WebBrowser.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\Mono.WebBrowser.dll</HintPath>
     </Reference>
     <Reference Include="MoodkieSecurity">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\MoodkieSecurity.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\MoodkieSecurity.dll</HintPath>
     </Reference>
     <Reference Include="MoonSharp.Interpreter">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\MoonSharp.Interpreter.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\MoonSharp.Interpreter.dll</HintPath>
     </Reference>
     <Reference Include="Steamworks">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\Steamworks.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\Steamworks.dll</HintPath>
     </Reference>
     <Reference Include="Ui">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\Ui.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\Ui.dll</HintPath>
     </Reference>
     <Reference Include="Unity.Analytics.DataPrivacy">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\Unity.Analytics.DataPrivacy.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\Unity.Analytics.DataPrivacy.dll</HintPath>
     </Reference>
     <Reference Include="Unity.Analytics.StandardEvents">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\Unity.Analytics.StandardEvents.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\Unity.Analytics.StandardEvents.dll</HintPath>
     </Reference>
     <Reference Include="Unity.Analytics.Tracker">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\Unity.Analytics.Tracker.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\Unity.Analytics.Tracker.dll</HintPath>
     </Reference>
     <Reference Include="Unity.Burst">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\Unity.Burst.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\Unity.Burst.dll</HintPath>
     </Reference>
     <Reference Include="Unity.Burst.Unsafe">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\Unity.Burst.Unsafe.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\Unity.Burst.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="Unity.Collections">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\Unity.Collections.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\Unity.Collections.dll</HintPath>
     </Reference>
     <Reference Include="Unity.Collections.LowLevel.ILSupport">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\Unity.Collections.LowLevel.ILSupport.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\Unity.Collections.LowLevel.ILSupport.dll</HintPath>
     </Reference>
     <Reference Include="Unity.Mathematics">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\Unity.Mathematics.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\Unity.Mathematics.dll</HintPath>
     </Reference>
     <Reference Include="Unity.MemoryProfiler">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\Unity.MemoryProfiler.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\Unity.MemoryProfiler.dll</HintPath>
     </Reference>
     <Reference Include="Unity.Profiling.Core">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\Unity.Profiling.Core.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\Unity.Profiling.Core.dll</HintPath>
     </Reference>
     <Reference Include="Unity.Services.Analytics">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\Unity.Services.Analytics.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\Unity.Services.Analytics.dll</HintPath>
     </Reference>
     <Reference Include="Unity.Services.Core">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\Unity.Services.Core.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\Unity.Services.Core.dll</HintPath>
     </Reference>
     <Reference Include="Unity.Services.Core.Analytics">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\Unity.Services.Core.Analytics.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\Unity.Services.Core.Analytics.dll</HintPath>
     </Reference>
     <Reference Include="Unity.Services.Core.Configuration">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\Unity.Services.Core.Configuration.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\Unity.Services.Core.Configuration.dll</HintPath>
     </Reference>
     <Reference Include="Unity.Services.Core.Device">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\Unity.Services.Core.Device.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\Unity.Services.Core.Device.dll</HintPath>
     </Reference>
     <Reference Include="Unity.Services.Core.Environments">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\Unity.Services.Core.Environments.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\Unity.Services.Core.Environments.dll</HintPath>
     </Reference>
     <Reference Include="Unity.Services.Core.Environments.Internal">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\Unity.Services.Core.Environments.Internal.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\Unity.Services.Core.Environments.Internal.dll</HintPath>
     </Reference>
     <Reference Include="Unity.Services.Core.Internal">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\Unity.Services.Core.Internal.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\Unity.Services.Core.Internal.dll</HintPath>
     </Reference>
     <Reference Include="Unity.Services.Core.Networking">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\Unity.Services.Core.Networking.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\Unity.Services.Core.Networking.dll</HintPath>
     </Reference>
     <Reference Include="Unity.Services.Core.Registration">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\Unity.Services.Core.Registration.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\Unity.Services.Core.Registration.dll</HintPath>
     </Reference>
     <Reference Include="Unity.Services.Core.Scheduler">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\Unity.Services.Core.Scheduler.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\Unity.Services.Core.Scheduler.dll</HintPath>
     </Reference>
     <Reference Include="Unity.Services.Core.Telemetry">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\Unity.Services.Core.Telemetry.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\Unity.Services.Core.Telemetry.dll</HintPath>
     </Reference>
     <Reference Include="Unity.Services.Core.Threading">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\Unity.Services.Core.Threading.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\Unity.Services.Core.Threading.dll</HintPath>
     </Reference>
     <Reference Include="Unity.TextMeshPro">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\Unity.TextMeshPro.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\Unity.TextMeshPro.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.AccessibilityModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.AccessibilityModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.AccessibilityModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.AIModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.AIModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.AIModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.AMDModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.AMDModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.AMDModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.AndroidJNIModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.AndroidJNIModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.AndroidJNIModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.AnimationModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.AnimationModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.AnimationModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.ARModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.ARModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.ARModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.AssetBundleModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.AssetBundleModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.AssetBundleModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.AudioModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.AudioModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.AudioModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.ClothModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.ClothModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.ClothModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.ClusterInputModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.ClusterInputModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.ClusterInputModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.ClusterRendererModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.ClusterRendererModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.ClusterRendererModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.ContentLoadModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.ContentLoadModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.ContentLoadModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.CrashReportingModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.CrashReportingModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.CrashReportingModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.DirectorModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.DirectorModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.DirectorModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.DSPGraphModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.DSPGraphModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.DSPGraphModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.GameCenterModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.GameCenterModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.GameCenterModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.GIModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.GIModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.GIModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.GraphicsStateCollectionSerializerModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.GraphicsStateCollectionSerializerModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.GraphicsStateCollectionSerializerModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.GridModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.GridModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.GridModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.HierarchyCoreModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.HierarchyCoreModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.HierarchyCoreModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.HotReloadModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.HotReloadModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.HotReloadModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.ImageConversionModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.ImageConversionModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.ImageConversionModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.IMGUIModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.IMGUIModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.IMGUIModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.InputForUIModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.InputForUIModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.InputForUIModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.InputLegacyModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.InputLegacyModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.InputLegacyModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.InputModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.InputModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.InputModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.JSONSerializeModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.JSONSerializeModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.JSONSerializeModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.LocalizationModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.LocalizationModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.LocalizationModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.MarshallingModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.MarshallingModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.MarshallingModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.MultiplayerModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.MultiplayerModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.MultiplayerModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.NVIDIAModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.NVIDIAModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.NVIDIAModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.ParticleSystemModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.ParticleSystemModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.ParticleSystemModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.PerformanceReportingModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.PerformanceReportingModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.PerformanceReportingModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.Physics2DModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.Physics2DModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.Physics2DModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.PhysicsModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.PhysicsModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.PhysicsModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.ProfilerModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.ProfilerModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.ProfilerModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.PropertiesModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.PropertiesModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.PropertiesModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.RuntimeInitializeOnLoadManagerInitializerModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.RuntimeInitializeOnLoadManagerInitializerModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.RuntimeInitializeOnLoadManagerInitializerModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.ScreenCaptureModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.ScreenCaptureModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.ScreenCaptureModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.ShaderVariantAnalyticsModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.ShaderVariantAnalyticsModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.ShaderVariantAnalyticsModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.SharedInternalsModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.SharedInternalsModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.SharedInternalsModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.SpriteMaskModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.SpriteMaskModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.SpriteMaskModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.SpriteShapeModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.SpriteShapeModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.SpriteShapeModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.StreamingModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.StreamingModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.StreamingModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.SubstanceModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.SubstanceModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.SubstanceModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.SubsystemsModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.SubsystemsModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.SubsystemsModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.TerrainModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.TerrainModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.TerrainModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.TerrainPhysicsModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.TerrainPhysicsModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.TerrainPhysicsModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.TextCoreFontEngineModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.TextCoreFontEngineModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.TextCoreFontEngineModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.TextCoreModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.TextCoreModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.TextCoreModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.TextCoreTextEngineModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.TextCoreTextEngineModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.TextCoreTextEngineModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.TextRenderingModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.TilemapModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.TilemapModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.TilemapModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.TLSModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.TLSModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.TLSModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UaaLAnalyticsModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.UaaLAnalyticsModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.UaaLAnalyticsModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UI">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.UI.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.UI.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UIElementsModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.UIElementsModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.UIElementsModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UIElementsNativeModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.UIElementsNativeModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.UIElementsNativeModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UIModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.UIModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.UIModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UmbraModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.UmbraModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.UmbraModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UNETModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.UNETModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.UNETModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UnityAnalyticsCommonModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.UnityAnalyticsCommonModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.UnityAnalyticsCommonModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UnityAnalyticsModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.UnityAnalyticsModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.UnityAnalyticsModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UnityConnectModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.UnityConnectModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.UnityConnectModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UnityCurlModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.UnityCurlModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.UnityCurlModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UnityTestProtocolModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.UnityTestProtocolModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.UnityTestProtocolModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UnityWebRequestAssetBundleModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.UnityWebRequestAssetBundleModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.UnityWebRequestAssetBundleModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UnityWebRequestAudioModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.UnityWebRequestAudioModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.UnityWebRequestAudioModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UnityWebRequestModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.UnityWebRequestModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.UnityWebRequestModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UnityWebRequestTextureModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.UnityWebRequestTextureModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.UnityWebRequestTextureModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UnityWebRequestWWWModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.UnityWebRequestWWWModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.UnityWebRequestWWWModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.VehiclesModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.VehiclesModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.VehiclesModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.VFXModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.VFXModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.VFXModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.VideoModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.VideoModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.VideoModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.VirtualTexturingModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.VirtualTexturingModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.VirtualTexturingModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.VRModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.VRModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.VRModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.WindModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.WindModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.WindModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.XRModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.XRModule.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\UnityEngine.XRModule.dll</HintPath>
     </Reference>
     <Reference Include="Vectrosity">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\Vectrosity.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\Vectrosity.dll</HintPath>
     </Reference>
     <Reference Include="Youtube">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\Youtube.dll</HintPath>
+      <HintPath>$(FtDPath)\From_The_Depths_Data\Managed\Youtube.dll</HintPath>
     </Reference>
   </ItemGroup>
 

--- a/FTD.props.txt
+++ b/FTD.props.txt
@@ -1,0 +1,15 @@
+This is the example FTD Props file, that will be included with the build. Change the below path to your valid FTD install location.
+Create a copy of this file and remove the ".txt" extension and this will allow the project to find any needed imports for FTD mod Compliation
+
+
+---------------------------------------------
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- 
+      This is the path to YOUR From the Depths installation folder.
+      This file should NOT be committed to Git.
+    -->
+    <FtDPath>E:\Games\Steam\steamapps\common\From The Depths</FtDPath>
+  </PropertyGroup>
+</Project>

--- a/NewShieldBlockSystem/DomeShieldConstants.cs
+++ b/NewShieldBlockSystem/DomeShieldConstants.cs
@@ -29,5 +29,10 @@ namespace DomeShieldTwo.newshieldblocksystem
         public static float ACPerHardener = 50f;
 
         public static float HealthPerEnergy = 1f;
+
+        public static float ActiveRegenEPPMulti = 2f;
+        public static float PassiveRegenEPPMulti = 1.0f;
+        public static float IdleEPPMulti = .1f;
+
     }
 }


### PR DESCRIPTION
Currently you have the imports hard coded into the .csproj file. This is BAD, for using a github since anyone who clones it will be fighting over the INSTALL location of FTD. 
This system fixes that. By using a .props file, that isn't synced to github or between users to specify the FTD install location and just use a link to said file in the .csproj file. This should make this much easier to deal with between users. 